### PR TITLE
.

### DIFF
--- a/infra/web-adapter/src/test/kotlin/kr/pe/hws/stockmanager/webadapter/feign/client/api/KisApiTest.kt
+++ b/infra/web-adapter/src/test/kotlin/kr/pe/hws/stockmanager/webadapter/feign/client/api/KisApiTest.kt
@@ -16,8 +16,15 @@ class KisApiTest {
 
 
     @Test
-    fun getKrIndexChart() {
+    fun getKospiIndexChart() {
         val chart = fetcher.fetchKrIndexChart(IndexType.KOSPI)
+        Assertions.assertNotNull(chart)
+        println(chart)
+    }
+
+    @Test
+    fun getKosdaqIndexChart() {
+        val chart = fetcher.fetchKrIndexChart(IndexType.KOSDAQ)
         Assertions.assertNotNull(chart)
         println(chart)
     }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- **Refactor**: `getKrIndexChart` 메서드의 이름을 `getKospiIndexChart`로 변경하여 명확성을 개선했습니다.
- **Test**: KOSDAQ 지수 차트를 가져오는 기능을 테스트하는 새로운 메서드 `getKosdaqIndexChart`를 추가했습니다. 

이 변경 사항은 사용자에게 KOSPI 및 KOSDAQ 지수 차트에 대한 보다 정확한 정보를 제공하며, 테스트 커버리지를 향상시킵니다.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->