### PR TITLE
.

### DIFF
--- a/infra/web-adapter/src/test/kotlin/kr/pe/hws/stockmanager/webadapter/feign/client/api/KisApiTest.kt
+++ b/infra/web-adapter/src/test/kotlin/kr/pe/hws/stockmanager/webadapter/feign/client/api/KisApiTest.kt
@@ -44,6 +44,13 @@ class KisApiTest {
     }
 
     @Test
+    fun getPhiladelphiaIndexChart() {
+        val chart = fetcher.fetchOverSeaIndexChart(IndexType.PHILADELPHIA)
+        Assertions.assertNotNull(chart)
+        println(chart)
+    }
+
+    @Test
     fun getKrStockVolumeRank() {
         val data = fetcher.fetchKrStockVolumeRank("0000")
         Assertions.assertNotNull(data)


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Test: `KisApiTest` 클래스에 새로운 테스트 메서드 `getPhiladelphiaIndexChart()` 추가
  - 이 메서드는 해외 지수 차트를 가져오는 기능을 검증하며, 반환된 차트가 null이 아님을 확인합니다. 
  - 기존 코드에는 영향을 미치지 않으며, 외부 인터페이스나 동작의 변경은 없습니다. 

이번 업데이트는 테스트 커버리지를 향상시켜 안정성을 높이는 데 기여합니다.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->